### PR TITLE
Fix bug when Reference finder when no gene or functions are found

### DIFF
--- a/utils/reference_checker.py
+++ b/utils/reference_checker.py
@@ -70,9 +70,9 @@ def get_keywords_combinations(paragraph, config, verbose=False):
     genes = get_genes_from_paragraph(paragraph, config, verbose)
     functions = get_molecular_functions_from_paragraph(paragraph, config, verbose)
     if genes is None or functions is None: # CH updated the condition
-        return [], True # SA modified binary return
+        return None, [], [], True # SA modified binary return
     if genes[0]=='Unknown' or functions[0]=='Unknown':
-        return [], False # SA modified
+        return None, [], [], False # SA modified
     # CH modify the keywords combination, so search for Titles first then Title/Abstracts
     gene_query_title = " OR ".join(["(%s[Title])"%gene for gene in genes])
     keywords_title = [gene_query_title + " AND (%s[Title])"%function for function in functions]
@@ -400,6 +400,10 @@ def get_references_for_paragraphs(paragraphs, email, config, n=5, verbose=False,
             print("""Extracting keywords from paragraph\nParagraph:\n%s"""%paragraph)
             print("="*75)
         keywords, genes, functions, flag_working = get_keywords_combinations(paragraph, config=config, verbose=verbose) # SA: modified
+        if keywords is None:
+            print("No keyword generated", skip referencing)
+            references_paragraphs.append([])
+            continue
         if verbose:
             print("PubMed Keywords: ", keywords)
         if flag_working: # collect genes or functions keywords return None and come back later 


### PR DESCRIPTION
when no gene or function found in paragraphs, it gives None and empty sets, and skip finding referencing